### PR TITLE
Fix idempotency issues

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: configure Redis server
   include: server.yml
-  tags: redis_config
+  tags: redis_server
   when: redis_srv_enabled
 
 - name: configure Redis sentinel

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -49,15 +49,6 @@
       mode: "0644"
   when: redis_srv_log_file != ""
 
-- name: mark file as ansible managed
-  lineinfile:
-    dest: "{{ redis_sent_sys_confFile }}"
-    state: present
-    regexp: "Ansible Managed"
-    insertbefore: BOF
-    line: "# Ansible Managed"
-  register: managed
-
 - name: create redis config file
   template:
     src: redis.conf.j2
@@ -65,7 +56,6 @@
     owner: redis
     mode: "0600"
   notify: restart redis
-  when: managed.changed or redis_reconfig is defined and redis_reconfig
 
 - name: install server service file
   template:

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -3,7 +3,7 @@
 
 # System
 daemonize {{ 'yes' if redis_srv_sys_daemonize else 'no' }}
-pidfile {{ redis_srv_sys_pidFile }}
+pidfile "{{ redis_srv_sys_pidFile }}"
 
 # Connections
 port {{ redis_srv_conn_port }}
@@ -18,8 +18,8 @@ tcp-backlog {{ redis_srv_conn_tcpBacklog }}
 
 # Storage
 databases {{ redis_srv_stor_databases }}
-dir {{ redis_srv_stor_dir }}
-dbfilename {{ redis_srv_stor_dbFile }}
+dir "{{ redis_srv_stor_dir }}"
+dbfilename "{{ redis_srv_stor_dbFile }}"
 {% for save in redis_srv_stor_save -%}
 save {{ save }}
 {% endfor -%}
@@ -27,7 +27,7 @@ stop-writes-on-bgsave-error {{ 'yes' if redis_srv_stor_stopWritesOnBgSaveError e
 rdbcompression {{ 'yes' if redis_srv_stor_rdbCompression else 'no' }}
 rdbchecksum {{ 'yes' if redis_srv_stor_rdbChecksum else 'no' }}
 appendonly {{ 'yes' if redis_srv_stor_appendOnly else 'no' }}
-appendfilename {{ redis_srv_stor_appendFile }}
+appendfilename "{{ redis_srv_stor_appendFile }}"
 appendfsync {{ redis_srv_stor_appendFsync }}
 no-appendfsync-on-rewrite {{ redis_srv_stor_noAppendFsyncOnRewrite }}
 auto-aof-rewrite-percentage {{ redis_srv_stor_autoAofRewritePercentage }}
@@ -35,8 +35,8 @@ auto-aof-rewrite-min-size {{ redis_srv_stor_autoAofRewriteMinSize }}
 
 # Security
 {% if redis_srv_sec_password -%}
-masterauth {{ redis_srv_sec_password }}
-requirepass {{ redis_srv_sec_password }}
+masterauth "{{ redis_srv_sec_password }}"
+requirepass "{{ redis_srv_sec_password }}"
 {% endif %}
 {% for command in redis_srv_sec_renameCommands %}
 rename-command {{ command }}


### PR DESCRIPTION
Sentinel writes on config files, and it requires that filepaths have double-quotes. This PR fixes the idempotency issue caused by this problem.